### PR TITLE
Work around OpenRC socket being possibly left over.

### DIFF
--- a/net-analyzer/crowdsec/files/crowdsec.openrc
+++ b/net-analyzer/crowdsec/files/crowdsec.openrc
@@ -1,6 +1,6 @@
 #!/sbin/openrc-run
 
-name="crowdsec"
+name="CrowdSec"
 description="CrowdSec agent"
 
 crowdsec_config="${crowdsec_config:-/etc/crowdsec/config.yaml}"
@@ -28,6 +28,7 @@ checkconfig() {
 }
 
 start_pre() {
+	rm -f "${RC_SVCDIR}/supervise-${RC_SVCNAME}.sock" || return 1
 	if [ "${RC_CMD}" != "restart" ]; then
 		checkconfig
 	fi

--- a/net-analyzer/cs-firewall-bouncer/files/cs-firewall-bouncer.openrc
+++ b/net-analyzer/cs-firewall-bouncer/files/cs-firewall-bouncer.openrc
@@ -35,5 +35,6 @@ checkconfig() {
 # The bouncer's -t option initializes its firewall backend. Run it only from
 # start_pre, after any previous bouncer process has stopped.
 start_pre() {
+	rm -f "${RC_SVCDIR}/supervise-${RC_SVCNAME}.sock" || return 1
 	checkconfig
 }


### PR DESCRIPTION
Work around a race condition where OpenRC can keep the socket file in  `/run/` hanging around, preventing a restart of the service. Grr.

Also fix the same `Crowdsec`->`CrowdSec` capitalization as was done with the bouncer while I'm here.